### PR TITLE
Fix mnemonics

### DIFF
--- a/tools/generate-address.html
+++ b/tools/generate-address.html
@@ -99,7 +99,7 @@
                     $("#address").val(wallet.publicKey.toAddress())
                     $("#addressSerialize").val(wallet.publicKey.toAddress().serialize())
 
-                    $("#privateKeyMnemonic").val(String(Nimiq.MnemonicUtils.entropyToMnemonic(wallet.keyPair.privateKey.serialize())).replace(/,/g, ", "))
+                    $("#privateKeyMnemonic").val(String(Nimiq.MnemonicUtils.entropyToLegacyMnemonic(wallet.keyPair.privateKey.serialize())).replace(/,/g, ", "))
                     $("#privateKey").val(wallet.keyPair.privateKey)
                     $("#privateKeySerialize").val(wallet.keyPair.privateKey.serialize())
                     $("#privateKeyHex").val(wallet.keyPair.privateKey.toHex())

--- a/tools/import-from-mnemonic.html
+++ b/tools/import-from-mnemonic.html
@@ -21,6 +21,9 @@
                     </div>
                 </div>
             </div>
+            <p class="alert alert-warning" role="alert" id="seedWarning" style="display: none;">
+                <strong>Warning:</strong> These 24 words represent an Account Seed. All information on this page is about the first derived address only!
+            </p>
             <br>
             <div class="row d-none">
                 <div class="col-xs-12 col-md-6">
@@ -89,16 +92,24 @@
                 await Nimiq.load()
             })()
 
-            function mnemonicToEntropy(mnemonic) {
+            const derivationPath = "m/44'/242'/0'/0'"
+
+            function mnemonicToKeyPair(mnemonic) {
                 mnemonic = mnemonic.replace(/, /g, " ").replace(/,/g, " ")
                 try {
-                    return Nimiq.MnemonicUtils.mnemonicToEntropy(mnemonic)
+                    const entropy = Nimiq.MnemonicUtils.mnemonicToEntropy(mnemonic)
+                    $("#seedWarning").show()
+                    const masterKey = entropy.toExtendedPrivateKey()
+                    const derivedPrivateKey = masterKey.derivePath(derivationPath).privateKey
+                    return Nimiq.KeyPair.derive(derivedPrivateKey)
                 } catch (error) {
                     // Ignore
                 }
 
                 try {
-                    return Nimiq.MnemonicUtils.legacyMnemonicToEntropy(mnemonic)
+                    const entropy = Nimiq.MnemonicUtils.legacyMnemonicToEntropy(mnemonic)
+                    $("#seedWarning").hide()
+                    return Nimiq.KeyPair.derive(new Nimiq.PrivateKey(entropy.serialize()))
                 } catch (error) {
                     // Ignore
                 }
@@ -107,8 +118,8 @@
 
             $("#privateKeyMnemonic").on("input", () => {
                 try {
-                    const entropy = mnemonicToEntropy($("#privateKeyMnemonic").val())
-                    const wallet = new Nimiq.Wallet(Nimiq.KeyPair.derive(new Nimiq.PrivateKey(entropy.serialize())))
+                    const keyPair = mnemonicToKeyPair($("#privateKeyMnemonic").val())
+                    const wallet = new Nimiq.Wallet(keyPair)
                     $(".d-none").removeClass("d-none")
                     $("#publicKeyUserFriendly").val(wallet.publicKey.toAddress().toUserFriendlyAddress())
                     $("#publicKey").val(wallet.publicKey)
@@ -117,7 +128,7 @@
                     $("#address").val(wallet.publicKey.toAddress())
                     $("#addressSerialize").val(wallet.publicKey.toAddress().serialize())
 
-                    $("#privateKeyMnemonicWords").val(String(Nimiq.MnemonicUtils.entropyToMnemonic(wallet.keyPair.privateKey.serialize())).replace(/,/g, ", "))
+                    $("#privateKeyMnemonicWords").val(String(Nimiq.MnemonicUtils.entropyToLegacyMnemonic(wallet.keyPair.privateKey.serialize())).replace(/,/g, ", "))
                     $("#privateKey").val(wallet.keyPair.privateKey)
                     $("#privateKeySerialize").val(wallet.keyPair.privateKey.serialize())
                     $("#privateKeyHex").val(wallet.keyPair.privateKey.toHex())

--- a/tools/sign-message-mnemonic.html
+++ b/tools/sign-message-mnemonic.html
@@ -55,17 +55,22 @@
             })()
 
             let keyPair
+            const derivationPath = "m/44'/242'/0'/0'"
 
-            function mnemonicToEntropy(mnemonic) {
+            function mnemonicToKeyPair(mnemonic) {
                 mnemonic = mnemonic.replace(/, /g, " ").replace(/,/g, " ")
                 try {
-                    return Nimiq.MnemonicUtils.mnemonicToEntropy(mnemonic)
+                    const entropy = Nimiq.MnemonicUtils.mnemonicToEntropy(mnemonic)
+                    const masterKey = entropy.toExtendedPrivateKey()
+                    const derivedPrivateKey = masterKey.derivePath(derivationPath).privateKey
+                    return Nimiq.KeyPair.derive(derivedPrivateKey)
                 } catch (error) {
                     // Ignore
                 }
 
                 try {
-                    return Nimiq.MnemonicUtils.legacyMnemonicToEntropy(mnemonic)
+                    const entropy = Nimiq.MnemonicUtils.legacyMnemonicToEntropy(mnemonic)
+                    return Nimiq.KeyPair.derive(new Nimiq.PrivateKey(entropy.serialize()))
                 } catch (error) {
                     // Ignore
                 }
@@ -74,8 +79,7 @@
 
             $("#privateKeyMnemonic").on("input", () => {
                 try {
-                    const entropy = mnemonicToEntropy($("#privateKeyMnemonic").val())
-                    keyPair = Nimiq.KeyPair.derive(new Nimiq.PrivateKey(entropy.serialize()))
+                    keyPair = mnemonicToKeyPair($("#privateKeyMnemonic").val())
                     $("#publicKey").val(keyPair.publicKey.toAddress().toUserFriendlyAddress())
                     $(".d-none").removeClass("d-none")
                 } catch (error) {
@@ -93,7 +97,7 @@
                     const proof = Nimiq.SignatureProof.singleSig(keyPair.publicKey, signature)
                     if(!proof.verify(Nimiq.Address.fromString($("#publicKey").val()), buffer))
                         throw new Error("Verification failed")
-                    
+
                     const data = {
                         address: $("#publicKey").val(),
                         message: message,


### PR DESCRIPTION
Nimiq Tools mix the generation of new (seed) mnemonics with the derivation of old private keys, which makes these tools incompatible with how the Safe handles it and how mnemonics should be handled.

This PR fixes these shortcomings and creates proper legacy mnemnics for private keys and properly converts entered new mnemonics into their corresponding derived keypair.

Also keep in mind that there is an overlap of 1-in-256 mnemonics that can be both privatekey and seed mnemonics (due to how the checksum algorithm works). So if your tools should primarily handle legacy (privatekey) mnemonics, it makes sense to switch the order in which mnemonics are interpreted to try the legacy method first.